### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "ruby"
+  run = "cd app && ruby main.rb"
+  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # lab-xp
+[![Run on Repl.it](https://repl.it/badge/github/danielhrc/lab-xp)](https://repl.it/github/danielhrc/lab-xp)
 ## Exemplo de execução:
-https://repl.it/@DanielHenriqueH/Curl-em-Ruby-com-save-em-JSON
+
+https://repl.it/@DanielHenriqueH/lab-xp
 ## Instruções para rodar:
 1. cd app
 2. Use uma query válida em uma file app/QUERY.rb


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).